### PR TITLE
Fix return value in checkWordValidity wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -2544,8 +2544,8 @@
         // Add win condition check to the checkWordValidity function
         const originalCheckWordValidity = checkWordValidity;
         checkWordValidity = async function() {
-            await originalCheckWordValidity.apply(this, arguments);
-            
+            const result = await originalCheckWordValidity.apply(this, arguments);
+
             // Update the appropriate game state object based on current mode
             if (currentMode === 'classic') {
                 classicGameState = {...gameState};
@@ -2555,6 +2555,8 @@
                 saveGameState(false);
                 dailyChallenge.checkWin();
             }
+
+            return result;
         };
 
         // Add this after the dailyChallenge initialization


### PR DESCRIPTION
## Summary
- ensure overridden `checkWordValidity` returns the original result

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f76f7cf708328b4977af7e20850c3